### PR TITLE
Fix admin calendar modal element

### DIFF
--- a/app/admin/calendar/page.js
+++ b/app/admin/calendar/page.js
@@ -6,7 +6,7 @@ import CalendarLayout from '../../../components/CalendarLayout';
 import { supabase } from '../../../lib/supabaseClient';
 import Modal from 'react-modal';
 
-Modal.setAppElement('#__next');
+Modal.setAppElement('body');
 
 export default function AdminCalendarPage() {
   const [events, setEvents] = useState([]);


### PR DESCRIPTION
## Summary
- point admin calendar modal to `body` as the React app element

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840e7e49288832498a862564d2a5e81