### PR TITLE
Fix assignments link in CalendarLayout

### DIFF
--- a/components/CalendarLayout.jsx
+++ b/components/CalendarLayout.jsx
@@ -114,9 +114,9 @@ export default function CalendarLayout({ children }) {
               </li>
               <li>
                 <Link
-                  href="/teacher"
+                  href="/teacher/assignments"
                   className={`block px-4 py-2 text-sm font-medium ${
-                    pathname === '/teacher'
+                    pathname === '/teacher/assignments'
                       ? 'bg-white text-blue-900'
                       : 'text-blue-800 hover:bg-white hover:text-blue-900'
                   }`}


### PR DESCRIPTION
## Summary
- set assignments link href to `/teacher/assignments`
- update active state check

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e7e19d88832487c237387215ea8e