### PR TITLE
Fix variable name causing auth check failure

### DIFF
--- a/app/admin/calendar/page.js
+++ b/app/admin/calendar/page.js
@@ -26,11 +26,11 @@ export default function AdminCalendarPage() {
   useEffect(() => {
     const initialize = async () => {
       const { data: { user: currentUser } } = await supabase.auth.getUser();
-      if (!currentCurrentuser) {
+      if (!currentUser) {
         window.location.href = '/login?role=admin';
         return;
       }
-      setUser(currentCurrentuser);
+      setUser(currentUser);
 
       // Fetch ALL events (admins see everything)
       await fetchEvents();


### PR DESCRIPTION
## Summary
- fix typo `currentCurrentuser` in admin calendar page

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser)*

------
https://chatgpt.com/codex/tasks/task_e_6840e7dda8188324a6ed09b5f69ba851